### PR TITLE
Implement flexible GGUF split loading

### DIFF
--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -1511,6 +1511,13 @@ gpt_params_context gpt_params_parser_init(gpt_params & params, llama_example ex,
     ).set_env("LLAMA_ARG_RPC"));
 #endif
     add_opt(llama_arg(
+        {"--splits"}, "LIST",
+        "comma separated list of GGUF split indexes to load (add 0 to load tensors from the first split)",
+        [](gpt_params & params, const std::string & value) {
+            params.gguf_splits = value;
+        }
+    ));
+    add_opt(llama_arg(
         {"--mlock"},
         "force system to keep model in RAM rather than swapping or compressing",
         [](gpt_params & params) {

--- a/common/common.cpp
+++ b/common/common.cpp
@@ -1943,6 +1943,7 @@ struct llama_model_params llama_model_params_from_gpt_params(const gpt_params & 
     mparams.n_world         = params.n_world;
     mparams.rank            = params.rank;
     mparams.rpc_servers     = params.rpc_servers.c_str();
+    mparams.gguf_splits     = params.gguf_splits.c_str();
     mparams.main_gpu        = params.main_gpu;
     mparams.split_mode      = params.split_mode;
     mparams.tensor_split    = params.tensor_split;

--- a/common/common.h
+++ b/common/common.h
@@ -217,6 +217,7 @@ struct gpt_params {
     std::string lookup_cache_dynamic = ""; // path of dynamic ngram cache file for lookup decoding          // NOLINT
     std::string logits_file          = ""; // file for saving *all* logits                                  // NOLINT
     std::string rpc_servers          = ""; // comma separated list of RPC servers                           // NOLINT
+    std::string gguf_splits          = ""; // comma separated list of GGUF split indexes                 // NOLINT
 
     std::vector<std::string> in_files;   // all input files
     std::vector<std::string> antiprompt; // strings upon which more user input is prompted (a.k.a. reverse prompts)

--- a/include/llama.h
+++ b/include/llama.h
@@ -297,6 +297,8 @@ extern "C" {
 
         // comma separated list of RPC servers to use for offloading
         const char * rpc_servers;
+        // comma separated list of GGUF split indexes to load; include 0 if the first split's tensors are needed
+        const char * gguf_splits;
 
         // Called with a progress value between 0.0 and 1.0. Pass NULL to disable.
         // If the provided progress_callback returns true, model loading continues.


### PR DESCRIPTION
## Summary
- allow specifying split indexes via `--splits`
- propagate split list through model params
- loader opens only selected GGUF splits
- document loading multiple split files