### PR TITLE
Feat/enable rank specific gguf file loading

### DIFF
--- a/common/arg.cpp
+++ b/common/arg.cpp
@@ -1511,6 +1511,13 @@ gpt_params_context gpt_params_parser_init(gpt_params & params, llama_example ex,
     ).set_env("LLAMA_ARG_RPC"));
 #endif
     add_opt(llama_arg(
+        {"--splits"}, "LIST",
+        "comma separated list of GGUF split indexes to load (add 0 to load tensors from the first split)",
+        [](gpt_params & params, const std::string & value) {
+            params.gguf_splits = value;
+        }
+    ));
+    add_opt(llama_arg(
         {"--mlock"},
         "force system to keep model in RAM rather than swapping or compressing",
         [](gpt_params & params) {

--- a/common/common.cpp
+++ b/common/common.cpp
@@ -1943,6 +1943,7 @@ struct llama_model_params llama_model_params_from_gpt_params(const gpt_params & 
     mparams.n_world         = params.n_world;
     mparams.rank            = params.rank;
     mparams.rpc_servers     = params.rpc_servers.c_str();
+    mparams.gguf_splits     = params.gguf_splits.c_str();
     mparams.main_gpu        = params.main_gpu;
     mparams.split_mode      = params.split_mode;
     mparams.tensor_split    = params.tensor_split;

--- a/common/common.h
+++ b/common/common.h
@@ -217,6 +217,7 @@ struct gpt_params {
     std::string lookup_cache_dynamic = ""; // path of dynamic ngram cache file for lookup decoding          // NOLINT
     std::string logits_file          = ""; // file for saving *all* logits                                  // NOLINT
     std::string rpc_servers          = ""; // comma separated list of RPC servers                           // NOLINT
+    std::string gguf_splits          = ""; // comma separated list of GGUF split indexes                 // NOLINT
 
     std::vector<std::string> in_files;   // all input files
     std::vector<std::string> antiprompt; // strings upon which more user input is prompted (a.k.a. reverse prompts)

--- a/include/llama.h
+++ b/include/llama.h
@@ -297,6 +297,8 @@ extern "C" {
 
         // comma separated list of RPC servers to use for offloading
         const char * rpc_servers;
+        // comma separated list of GGUF split indexes to load; include 0 if the first split's tensors are needed
+        const char * gguf_splits;
 
         // Called with a progress value between 0.0 and 1.0. Pass NULL to disable.
         // If the provided progress_callback returns true, model loading continues.

--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -4766,9 +4766,17 @@ struct llama_model_loader {
             trace = atoi(getenv("LLAMA_TRACE"));
         }
 
-        if (split_str && split_str[0] != '\0') {
-            for (int s : string_split<int>(split_str, ',')) {
-                if (s >= 0) split_list.insert((uint32_t)s);
+        if (split_str && *split_str) {
+            std::string tmp{split_str};
+            std::stringstream ss(tmp);
+            std::string tok;
+            while (std::getline(ss, tok, ',')) {
+                try {
+                    auto v = std::stoi(tok);
+                    if (v >= 0) split_list.insert(static_cast<uint32_t>(v));
+                } catch (...) {
+                    // ignore bad tokens
+                }
             }
         }
 


### PR DESCRIPTION
# Motivation

`prima.cpp` is designed to serve large models that cannot fit into a single device. However, its current implementation requires access to the **complete GGUF file**, even when the model is split into multiple parts. Regardless of whether multiple GGUF files exist, **all splits must be downloaded and stored on each device**, even though only a subset of layers is actually loaded into RAM or VRAM. This makes the system infeasible for devices with **limited local storage capacity**.

# Original Loading Process

At a high level, in the multi-split GGUF scenario, `prima.cpp`:

1. Loads the **first split** to read metadata.
2. Parses the number of splits, model architecture, and tensor definitions using memory-mapped I/O (`mmap`) through the `llama_model_loader`.
3. Once all metadata is parsed, it begins loading the actual tensor data using `llm_load_llama_tensors`.

During this process, the function `this_layer_is_mine(i, n_world, my_rank, n_layer_window)` is used to check if a given layer belongs to the current rank. If not, it skips loading that layer. While this avoids loading unneeded data into memory, the device must still **store all GGUF splits** locally, which is inefficient.

# Approach

To address this, I introduced a new argument called `--splits`, allowing users to **explicitly specify which GGUF splits should be loaded for each rank**. This provides more flexibility, especially for devices that **cannot store the full set of GGUF files**.

However, determining the correct split files to load is non-trivial. If relying on the default layer assignment logic in `prima.cpp` solver, users only know which layers are needed **at runtime**. Instead, it's better to **manually specify the layer assignment** using the `--n-layer-window` (`-lw`) flag. This way, users can precompute which splits contain the relevant layers.

For more details on `prima.cpp`’s layer assignment policy and split mapping examples, refer to the updated `README.md` section.